### PR TITLE
Turn off useCookiePersistence

### DIFF
--- a/NuxeoSDK/NuxeoSDK/Classes/NUXSession.m
+++ b/NuxeoSDK/NuxeoSDK/Classes/NUXSession.m
@@ -118,7 +118,7 @@ NSString *const kApiPrefix = @"ApiPrefix";
 - (ASIHTTPRequest *)httpRequestWithRequest:(NUXRequest *)nRequest withCompletionBlock:(NUXBasicBlock)completion failureBlock:(NUXBasicBlock)failure {
     ASIHTTPRequest *request = [nRequest requestASI];
     request.shouldContinueWhenAppEntersBackground = nRequest.shouldContinueWhenAppEntersBackground;
-
+    [request setUseCookiePersistence:NO];
     [request setRequestMethod:nRequest.method];
     request.username = nRequest.username;
     request.password = nRequest.password;


### PR DESCRIPTION
Hi Guy

After login successfully with correct username, password;
Nuxeo SDK request can still return login successfully, if use the wrong username and password.

This pull request fix them all.

Thank you
